### PR TITLE
🐛 Fix generating license from project folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To run the tool make sure you have installed
 
 The program accepts the following arguments:
 
-- **project**: the project file to analyze for third-parties.
+- **project**: the project file to analyze for third-parties or its folder.
 - **output**: the output file path. By default in the current directory with
   name `THIRD-PARTY-NOTICES.TXT`.
 - **endpoint**: optional extra NuGet repository endpoint to look for packages.

--- a/src/ThirdLicense/Program.cs
+++ b/src/ThirdLicense/Program.cs
@@ -43,7 +43,7 @@ namespace ThirdLicense
         /// <returns>The return code of the application.</returns>
         internal static Task<int> Main(string[] args)
         {
-            var projectArg = new Option<FileInfo>("--project") {
+            var projectArg = new Option<string>("--project") {
                 Description = "Project file to analyze third-parties",
                 IsRequired = true,
             };
@@ -66,9 +66,9 @@ namespace ThirdLicense
             return rootCommand.InvokeAsync(args);
         }
 
-        static async Task<int> Generate(FileInfo project, string endpoint, FileInfo output)
+        static async Task<int> Generate(string project, string endpoint, FileInfo output)
         {
-            Console.WriteLine("Project: {0}", project.FullName);
+            Console.WriteLine("Project: {0}", project);
             Console.WriteLine("Output file: {0}", output.FullName);
             if (!string.IsNullOrEmpty(endpoint)) {
                 Console.WriteLine("Endpoint: {0}", endpoint);
@@ -76,8 +76,8 @@ namespace ThirdLicense
                 Console.WriteLine("Default endpoints");
             }
 
-            if (!project.Exists) {
-                Console.WriteLine("Cannot find project file: {0}", project.FullName);
+            if (!File.Exists(project) && !Directory.Exists(project)) {
+                Console.WriteLine("Cannot find project file or folder: {0}", project);
                 return -1;
             }
 
@@ -86,7 +86,7 @@ namespace ThirdLicense
             }
 
             Stopwatch watch = Stopwatch.StartNew();
-            var dependencies = DotnetListStdoutAnalyzer.Analyze(project.FullName);
+            var dependencies = DotnetListStdoutAnalyzer.Analyze(project);
 
             using var nugetInspector = new NuGetProtocolInspector();
             if (!string.IsNullOrEmpty(endpoint)) {

--- a/src/ThirdLicense/ThirdLicense.csproj
+++ b/src/ThirdLicense/ThirdLicense.csproj
@@ -22,6 +22,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>dotnet-tool;third-party;license;dotnet</PackageTags>
     <PackageReleaseNotes>https://github.com/pleonex/ThirdLicense/releases</PackageReleaseNotes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ThirdLicense/ThirdLicense.csproj
+++ b/src/ThirdLicense/ThirdLicense.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Description>Generates transitive third-party license notice</Description>
     <Product>ThirdLicense</Product>
     <Copyright>(c) 2020 Benito Palacios Sánchez</Copyright>


### PR DESCRIPTION
After previous PR that resolves relative paths, generating licenses passing the project folder failed. This was an undocumented feature that now it's working (and documented) again.